### PR TITLE
feat: add landing-start-spot instead landing-header

### DIFF
--- a/src/modules/LandingStartSpot/LandingStartSpot.tsx
+++ b/src/modules/LandingStartSpot/LandingStartSpot.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import EmailForm from '../../components/EmailForm';
+import data from './data.json';
+
+import '../Header/header.scss';
+
+export default function LandingStartSpot(): JSX.Element {
+  return (
+    <div className="start-card">
+      <div className="start-card-background">
+        <img className="start-card-img" src={data.imgSrc} alt={data.altDescription} />
+        <div className="img-gradient" />
+      </div>
+      <div className="start-card-content">
+        <h1>{data.title}</h1>
+        <h2>{data.annotation}</h2>
+        <EmailForm />
+      </div>
+    </div>
+  );
+}

--- a/src/modules/LandingStartSpot/data.json
+++ b/src/modules/LandingStartSpot/data.json
@@ -1,0 +1,9 @@
+{
+  "title": "Фильмы, сериалы и многое другое без ограничений.",
+  "annotation": "Смотрите где угодно. Отменить подписку можно в любое время.",
+  "imgSrc": "https://assets.nflxext.com/ffe/siteui/vlv3/20876cab-b49d-4957-bbaf-906ceb1c05f1/370ebdc0-5135-43c5-8aa4-14c48dfc1bee/BY-ru-20220117-popsignuptwoweeks-perspective_alpha_website_large.jpg",
+  "altDescription": "get started",
+  "formTitle": "Готовы смотреть? Введите адрес электронной почты, чтобы оформить или возобновить подписку.",
+  "placeLabel": "Адрес электронной почты",
+  "startButton": "Начать смотреть"
+}

--- a/src/modules/LandingStartSpot/index.tsx
+++ b/src/modules/LandingStartSpot/index.tsx
@@ -1,0 +1,3 @@
+import LandingStartSpot from './LandingStartSpot';
+
+export default LandingStartSpot;


### PR DESCRIPTION
Добавила отдельный компонент для хедера на стартовой страницы взамен LandingHeader, т.к хедер объединен в один файл
![image](https://user-images.githubusercontent.com/85902937/153185595-9f9e51b2-e769-413e-a510-7d93e0377552.png)
